### PR TITLE
Specify --distribution-type all

### DIFF
--- a/updatewrapper/src/main/kotlin/com/commit451/updatewrapper/Helper.kt
+++ b/updatewrapper/src/main/kotlin/com/commit451/updatewrapper/Helper.kt
@@ -8,7 +8,7 @@ import org.gradle.internal.os.OperatingSystem
 internal object Helper {
 
     const val COMMAND_VERSION = "./gradlew --version"
-    const val COMMAND_UPDATE = "./gradlew wrapper --gradle-version {version}"
+    const val COMMAND_UPDATE = "./gradlew wrapper --gradle-version {version} --distribution-type all"
 
 
     fun getCurrentVersion(): String {


### PR DESCRIPTION
This is preferred (and default) for Android development, and some IDEs
can take advantage of it.

https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:wrapper_generation